### PR TITLE
mention unimpaired's conflict marker navigation

### DIFF
--- a/source/vim/unimpaired.rst
+++ b/source/vim/unimpaired.rst
@@ -24,6 +24,10 @@ Unimpaired Cheatsheet
 +----------+--------------------------------------------+
 | ]l       | next location (location list)              |
 +----------+--------------------------------------------+
+| [n       | previous conflict marker (such as git's)   |
++----------+--------------------------------------------+
+| ]n       | next conflict marker (such as git's)       |
++----------+--------------------------------------------+
 | [q       | previous error (quickfix list)             |
 +----------+--------------------------------------------+
 | ]q       | next error (quickfix list)                 |


### PR DESCRIPTION
I just recently learned about that you can use `[n`  and `]n` to navigate conflict markers in a file with unimpaired. As I usually use your cheatsheet and it was missing, I thought I add it.

Thanks for putting together this handy list!